### PR TITLE
Arch support for linux download binaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@yaegassy/coc-marksman",
   "version": "0.2.10",
-  "marksmanBinVersion": "2023-04-12",
+  "marksmanBinVersion": "2023-06-01",
   "description": "Marksman (Markdown LSP server) extension for coc.nvim",
   "author": "yaegassy <yosstools@gmail.com>",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -185,13 +185,20 @@ function serverBinName(): string {
 
 function releaseBinName(): string {
   const platform = os.platform();
+  const arch = os.arch();
 
   if (platform === 'win32') {
     return 'marksman-windows.exe';
   } else if (platform === 'darwin') {
     return 'marksman-macos';
   } else if (platform === 'linux') {
-    return 'marksman-linux';
+    if (arch === 'x64') {
+      return 'marksman-linux-x64';
+    } else if (arch === 'arm64') {
+      return 'marksman-linux-arm64';
+    } else {
+      throw new Error(`Unsupported platform: ${platform}`);
+    }
   } else {
     throw new Error(`Unsupported platform: ${platform}`);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,10 +197,10 @@ function releaseBinName(): string {
     } else if (arch === 'arm64') {
       return 'marksman-linux-arm64';
     } else {
-      throw new Error(`Unsupported platform: ${platform}`);
+      throw new Error(`Unsupported ${arch} ${platform}`);
     }
   } else {
-    throw new Error(`Unsupported platform: ${platform}`);
+    throw new Error(`Unsupported ${arch} ${platform}`);
   }
 }
 


### PR DESCRIPTION
The binary name for Linux in GH Release has been changed since version `2023-06-01` of marksman.

- REF
  - <https://github.com/artempyanykh/marksman/releases/tag/2023-06-01>
  - <https://github.com/artempyanykh/marksman/pull/203>
- Before
  - `marksman-linux`
- After
  - `marksman-linux-arm64`
  - `marksman-linux-x64`

The download feature of coc-marksman has been adjusted.